### PR TITLE
Add Erlang R15 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,7 @@ Currently the following stack traces are supported:
 * Perl
 * Go
 * Node.js
+* Erlang (R15+)
 
 Is there another language you'd like supported? Open an issue with some sample stack traces or read on to learn how to add custom languages (pull requests welcome).
 

--- a/autoload/unstack/extractors.vim
+++ b/autoload/unstack/extractors.vim
@@ -35,6 +35,8 @@ function! unstack#extractors#GetDefaults()
   call add(extractors, unstack#extractors#Regex('\v^[ \t]*(.+):(\d+) \+0x\x+$', '\1', '\2'))
   " Node.js
   call add(extractors, unstack#extractors#Regex('\v^ +at .+\((.+):(\d+):\d+\)$', '\1', '\2'))
+  " Erlang R15+
+  call add(extractors, unstack#extractors#Regex('\v^.+\[\{file,"([^"]+)"\},\{line,([0-9]+)\}\]\}.*$', '\1', '\2'))
   return extractors
 endfunction
 


### PR DESCRIPTION
Hi - great plugin.

This small extension adds support for Erlang R15 (and greater) style stack traces.  It might be possible to write an extractor for Erlang R14 (which didn't include file and line number info) but that's currently beyond my understanding for vimscript.  

Since I write mostly R14 Erlang for work, I may try to work on it anyway though.
