### PR TITLE
valgrind support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,6 +52,7 @@ Currently the following stack traces are supported:
 * Go
 * Node.js
 * Erlang (R15+)
+* Valgrind
 
 Is there another language you'd like supported? Open an issue with some sample stack traces or read on to learn how to add custom languages (pull requests welcome).
 

--- a/autoload/unstack/extractors.vim
+++ b/autoload/unstack/extractors.vim
@@ -41,6 +41,8 @@ function! unstack#extractors#GetDefaults()
   call add(extractors, unstack#extractors#Regex('\v^ +at .+\((.+):(\d+):\d+\)$', '\1', '\2'))
   " Erlang R15+
   call add(extractors, unstack#extractors#Regex('\v^.+\[\{file,"([^"]+)"\},\{line,([0-9]+)\}\]\}.*$', '\1', '\2'))
+  " Valgrind
+  call add(extractors, unstack#extractors#Regex('\v^\=\=\d+\=\=[ \t]*%(at|by).*\((.+):(\d+)\)$', '\1', '\2', 1))
   return extractors
 endfunction
 

--- a/autoload/unstack/extractors.vim
+++ b/autoload/unstack/extractors.vim
@@ -1,7 +1,8 @@
 "unstack#extractors#Regex(regex, file_replacement, line_replacement) constructs {{{
 "an extractor that uses regexes 
-function! unstack#extractors#Regex(regex, file_replacement, line_replacement)
-  let extractor = {"regex": a:regex, "file_replacement": a:file_replacement, "line_replacement": a:line_replacement}
+function! unstack#extractors#Regex(regex, file_replacement, line_replacement, ...)
+  let extractor = {"regex": a:regex, "file_replacement": a:file_replacement,
+        \ "line_replacement": a:line_replacement, "reverse": (a:0 > 0) ? a:1 : 0}
   function extractor.extract(text) dict
     let stack = []
     for line in split(a:text, "\n")
@@ -12,6 +13,9 @@ function! unstack#extractors#Regex(regex, file_replacement, line_replacement)
         call add(stack, [fname, lineno])
       endif
     endfor
+    if self.reverse
+      call reverse(stack)
+    endif
     return stack
   endfunction
 

--- a/doc/unstack.txt
+++ b/doc/unstack.txt
@@ -190,6 +190,12 @@ let g:unstack_extractors = [unstack#extractors#Regex('\v^ *File "([^"]+)", line 
 "Add this extractor to the list of defaults
 let g:unstack_extractors = unstack#extractors#GetDefaults() + [unstack#extractors#Regex('\v^ *File "([^"]+)", line ([0-9]+).+', '\1', '\2')]
 
+unstack#extractors#Regex takes an optional argument that can be set to 1 to
+reverse the stack order (the default order is from top to bottom). For example
+for valgrind traces (which are in reversed order) you could use:
+
+unstack#extractors#Regex('\v^\=\=\d+\=\=[ \t]*%(at|by).*\((.+):(\d+)\)$', '\1', '\2', 1)
+
 ==============================================================================
 LIMITATIONS                                      *unstack_limitations*
 


### PR DESCRIPTION
This pull request add valgrind support. Since valgrind stack traces are printed in reversed order, the first commit adds support for reversed traces.