### PR TITLE
Guard for the mappings

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ No backwards compatability is guaranteed at this time.
 
 Usage
 -----
-Visually select part/all of a stacktrace and hit `<leader>s`. If you want to use a different map key, put `let g:unstack_mapkey=<F10>` (replacing `<F10>` with the key of your choice.)
+Visually select part/all of a stacktrace and hit `<leader>s`. If you want to use a different map key, put `let g:unstack_mapkey=<F10>` (replacing `<F10>` with the key of your choice, or an empty string to disable the mapping).
 
 You can also copy a stack trace to your system clipboard (from any program) and run `:UnstackFromClipboard`.
 

--- a/doc/unstack.txt
+++ b/doc/unstack.txt
@@ -89,7 +89,8 @@ OPTIONS                                          *unstack_options*
 let g:unstack_mapkey="<leader>s"                 *unstack_mapkey*
 
 Press this combination with a visual selection (or in normal mode followed by
-a motion) to edit 
+a motion) to edit. To not define any key mapping, assign an empty string to
+this variable.
 ------------------------------------------------------------------------------
 let g:unstack_showsigns=1                        *unstack_showsigns*
 

--- a/plugin/unstack.vim
+++ b/plugin/unstack.vim
@@ -7,8 +7,10 @@ let g:loaded_unstack = 1
 if !exists('g:unstack_mapkey')
   let g:unstack_mapkey = '<leader>s'
 endif
-exe 'nnoremap '.g:unstack_mapkey.' :set operatorfunc=unstack#Unstack<cr>g@'
-exe 'vnoremap '.g:unstack_mapkey.' :<c-u>call unstack#Unstack(visualmode())<cr>'
+if g:unstack_mapkey !~# '\s*'
+  exe 'nnoremap '.g:unstack_mapkey.' :set operatorfunc=unstack#Unstack<cr>g@'
+  exe 'vnoremap '.g:unstack_mapkey.' :<c-u>call unstack#Unstack(visualmode())<cr>'
+endif
 
 "List of text extractors
 if (!exists('g:unstack_extractors'))


### PR DESCRIPTION
Very nice plugin! Just a minor fix.

This commit allows to set the mappings only if `g:unstack_mapkey` is not empty (or whitespace). This allows the user to not set the mappings at all, which is currently not possible. As a side effects, is prevents creating garbage settings when `g:unstack_mapkey` is whitespace.

Please note that this is just a workaround, to not break backward-compatibility. The proper way to provide key mappings in a plugin is to expose `<Plug>` mappings.