### PR TITLE
Fix a bug with setting key mappings

### DIFF
--- a/plugin/unstack.vim
+++ b/plugin/unstack.vim
@@ -7,7 +7,7 @@ let g:loaded_unstack = 1
 if !exists('g:unstack_mapkey')
   let g:unstack_mapkey = '<leader>s'
 endif
-if g:unstack_mapkey !~# '\s*'
+if g:unstack_mapkey !~# '^\s*$'
   exe 'nnoremap '.g:unstack_mapkey.' :set operatorfunc=unstack#Unstack<cr>g@'
   exe 'vnoremap '.g:unstack_mapkey.' :<c-u>call unstack#Unstack(visualmode())<cr>'
 endif


### PR DESCRIPTION
Currently, key mappings are never set because the regex '\s*' matches all strings (including the empty string).

This change implements the actual intent behind #32, which introduced this bug.